### PR TITLE
依存パッケージのインストールをするmakeターゲットを用意

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+composer.phar

--- a/prod.mk
+++ b/prod.mk
@@ -1,0 +1,11 @@
+.PHONY: setup
+
+setup: composer.phar .env
+	./composer.phar install --no-dev --prefer-dist --optimize-autoloader --no-interaction
+
+composer.phar:
+	./script/setup-composer.sh
+
+.env:
+	cp .env.example .env
+

--- a/script/setup-composer.sh
+++ b/script/setup-composer.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE=$(curl -sSf https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
# refs
#1 

# 概要
* `make -f prod.mk setup` で依存モジュールのインストールが走るようにした