### PR TITLE
project rootをmountした状態でcomposer installを走らせる

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SERVICE_LABEL=com.pinkumohikan.valu-incentive-search.service
 dev/up:
 	cp .env.dev .env
 	docker-compose -f docker-compose.yml -f docker-compose-dev.yml up -d --build
+	$(MAKE) exec cmd="make -f docker-internal.mk setup"
 	$(MAKE) exec cmd="php artisan migrate --force"
 
 dev/down:


### PR DESCRIPTION
# refs
close https://github.com/pinkumohikan/valu-incentive-search/issues/24

# 概要
* `make dev/up` を実行した際、docker build時にcomposer installが走るが、変更の即時反映を目的としたmountによって `vendor` ディレクトリが上書きされてしまいアプリがまともに動かない
* 対応として、コンテナ起動後のmountされた状態で再度composer installを走らせる。するとローカル側に `vendor` が作られてアプリが動く状態になる
    * コンテナに保持されたcomposer cacheが聞くので、install時間は初回実行時よりも短い