### PR TITLE
開発環境でもfailure exitしたらコンテナをrestartさせる

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,10 +17,10 @@ services:
   app:
     volumes:
       - "./:/workspace" # コード変更を即座に反映させるため
-    restart: "no"
+    restart: "on-failure"
 
   queue-worker:
-    restart: "no"
+    restart: "on-failure"
 
 networks:
   valu-incentive-search:


### PR DESCRIPTION
# refs
https://github.com/pinkumohikan/valu-incentive-search/issues/28

# 概要
db準備が整うまでにqueue workerが接続を試みて死んだとき、コンテナ起動をリベンジさせる
see: https://docs.docker.com/compose/compose-file/compose-file-v2/#restart