### PR TITLE
jpeg画像がサポートできておらず、一部の優待情報を取り込めていなかった

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ COPY ./docker_files/nginx/ /etc/nginx
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-RUN apk add --no-cache libpng-dev jpeg-dev && \
+RUN apk add --no-cache libpng-dev jpeg-dev \
     && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
-    docker-php-ext-install gd
+    && docker-php-ext-install gd
 
 ENV COMPOSER_ALLOW_SUPERUSER = 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ COPY ./docker_files/nginx/ /etc/nginx
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-RUN apk add --no-cache libpng-dev && \
+RUN apk add --no-cache libpng-dev jpeg-dev && \
+    && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
     docker-php-ext-install gd
 
 ENV COMPOSER_ALLOW_SUPERUSER = 1


### PR DESCRIPTION
# 概要
jpeg画像がサポートできておらず、一部の優待情報を取り込めていなかった

```
[2018-10-28 11:45:17] development.ERROR: imagecreatefromstring(): No JPEG support in this PHP build {"exception":"[object] (ErrorException(code: 0): imagecreatefromstring(): No JPEG support in this PHP build at /workspace/app/Peanut/ValuIncentive/Thumbnail.php:20)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(2, 'imagecreatefrom...', '/workspace/app/...', 20, Array)
#1 /workspace/app/Peanut/ValuIncentive/Thumbnail.php(20): imagecreatefromstring('\\xFF\\xD8\\xFF\\xE0\\x00\\x10JFIF\\x00\\x01\\x01\\x00\\x00...')
#2 /workspace/app/Peanut/Valu/IncentiveLoader.php(35): Peanut\\ValuIncentive\\Thumbnail::create(Object(Peanut\\ValuIncentive\\ValuIncentive))
#3 /workspace/app/Jobs/LoadIncentive.php(29): Peanut\\Valu\\IncentiveLoader->load(Object(Peanut\\ValuOwner\\ValuOwner))
#4 [internal function]: App\\Jobs\\LoadIncentive->handle(Object(Peanut\\Valu\\IncentiveLoader))
#5 
...
```

# note
* 参考にした
    * https://qiita.com/takeru56/items/74d3e402660ae4473e88